### PR TITLE
BZ-5120: fix: resolve Blaze.process crash under Flutter scene-based lifecycle

### DIFF
--- a/ios/Classes/BlazeSdkFlutterPlugin.swift
+++ b/ios/Classes/BlazeSdkFlutterPlugin.swift
@@ -7,12 +7,14 @@ public class BlazeSdkFlutterPlugin: NSObject, FlutterPlugin {
 
     private var blaze: Blaze?
     private var methodChannel: FlutterMethodChannel?
+    private weak var registrar: FlutterPluginRegistrar?
 
     public static func register(with registrar: FlutterPluginRegistrar) {
         let channel = FlutterMethodChannel(
             name: "blaze_sdk_flutter", binaryMessenger: registrar.messenger())
         let instance = BlazeSdkFlutterPlugin()
         instance.methodChannel = channel
+        instance.registrar = registrar
         registrar.addMethodCallDelegate(instance, channel: channel)
     }
 
@@ -41,8 +43,7 @@ public class BlazeSdkFlutterPlugin: NSObject, FlutterPlugin {
         let initiatePayloadJson = safeParseJson(initiatePayload)
         DispatchQueue.main.async {
             if let blaze = self.blaze,
-                let rootViewController = UIApplication.shared.delegate?.window??
-                    .rootViewController
+                let rootViewController = self.registrar?.viewController
             {
                 blaze.initiate(
                     context: rootViewController,


### PR DESCRIPTION
### Ticket
BZ-5120

### Impacted Areas
- **iOS SDK bridge (Flutter plugin)** — checkout/payment flow no longer crashes on the latest Flutter, since the screen reference the SDK renders on is now fetched correctly.

### What is done?
- Plugin grabbed the app's screen reference once at startup, before iOS's new launch model had finished creating it — so it stored nothing (ios/Classes/BlazeSdkFlutterPlugin.swift).
- Fix: read that screen reference fresh each time it's actually needed, instead of a one-time snapshot that goes stale.
- Works on both old and new iOS launch models, so it's a safe, universal fix with no other changes required.

### Why is it done?
Tapping "Initiate SDK" → "Process" in the example app crashed on the latest Flutter version because Apple's newer iOS launch model builds the app's screen later than before, and the plugin was capturing that reference too early. This fix restores checkout/payment functionality for merchants on the current Flutter SDK.

### How to test it?
1. Open the example app and tap "Initiate SDK".
2. Tap "Process" — expect the checkout/payment flow to open normally instead of the app crashing.
3. Repeat on an app still using the older iOS launch model — expect the same working behavior (no regression).
4. Confirm no crash logs appear during either flow.

### Priority
**high**

### Environment Variables
No new environment variables.

### Dev Proofs
<img width="1168" height="1386" alt="Screenshot 2026-07-30 at 6 54 51 PM" src="https://github.com/user-attachments/assets/9f0d113d-73c7-4c1e-99cb-eda6a826f879" />
